### PR TITLE
Add reproducible build support

### DIFF
--- a/src/build/Makefile
+++ b/src/build/Makefile
@@ -204,7 +204,7 @@ tar:
 		tar install
 
 buildinfo: $(P9_XIP_TOOL) $(IMG_DIR)/$(IMAGE_SEEPROM_NAME).bin
-	./updateBuildTag.py $(P9_XIP_TOOL) $(IMG_DIR) $(IMAGE_SEEPROM_NAME)
+	if [ -z "$(REPRODUCIBLE)" ]; then ./updateBuildTag.py $(P9_XIP_TOOL) $(IMG_DIR) $(IMAGE_SEEPROM_NAME); fi
 
 add_LoaderAddr: $(P9_XIP_TOOL) $(IMG_DIR)/$(IMAGE_SEEPROM_NAME).out
 	$(P9_XIP_TOOL) $(IMG_DIR)/$(IMAGE_SEEPROM_NAME).bin set L1_LoaderAddr 0x`nm $(IMG_DIR)/$(IMAGE_SEEPROM_NAME).out | grep __l1Loader | cut -f 1 -d " "`


### PR DESCRIPTION
Allows REPRODUCIBLE=1 to be passed to make/op-build to optionally avoid stamping the build tag, which contains non-deterministic elements like hostname, user and timestamp.