### PR TITLE
Force Python2 for scripts

### DIFF
--- a/src/boot/sbeCompression.py
+++ b/src/boot/sbeCompression.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/build/Makefile
+++ b/src/build/Makefile
@@ -244,7 +244,7 @@ report: $(P9_XIP_TOOL) $(IMG_DIR)/$(IMAGE_NAME).bin
 
 # Create build Info file
 buildInfo:
-	python buildInfo.py $(GENFILES_DIR)
+	./buildInfo.py $(GENFILES_DIR)
 
 buildtag:
 	./updateBuildTag.py $(P9_XIP_TOOL) $(IMG_DIR) $(IMAGE_NAME)
@@ -321,7 +321,7 @@ ppe_trace_bin:
 
 # generate whitelist and blacklist security algorithm
 security: $(OBJDIR)
-	python $(SECURITY_SRC_DIR)/securityRegListGen.py -f $(SECURITY_LIST) -o $(GENFILES_DIR)
+	$(SECURITY_SRC_DIR)/securityRegListGen.py -f $(SECURITY_LIST) -o $(GENFILES_DIR)
 
 # Build hwp_error_info.H.  If the script fails then print the contents of
 # the header and then delete whatever garbage the script left to force it to

--- a/src/build/buildInfo.py
+++ b/src/build/buildInfo.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/build/parsAndCutElf.py
+++ b/src/build/parsAndCutElf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/build/sbeOpDistribute.py
+++ b/src/build/sbeOpDistribute.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/build/security/securityRegListGen.py
+++ b/src/build/security/securityRegListGen.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/build/updateBuildTag.py
+++ b/src/build/updateBuildTag.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/test/testcases/testExecutorCntrlTimer.py
+++ b/src/test/testcases/testExecutorCntrlTimer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/test/testcases/testExecutorMemory.py
+++ b/src/test/testcases/testExecutorMemory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/test/testcases/testExecutorPSU.py
+++ b/src/test/testcases/testExecutorPSU.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/test/testcases/testExecutorPutRing.py
+++ b/src/test/testcases/testExecutorPutRing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/test/testcases/testExecutorStopTimer.py
+++ b/src/test/testcases/testExecutorStopTimer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/test/testcases/testPSUSetFFDCAddr.py
+++ b/src/test/testcases/testPSUSetFFDCAddr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/test/testcases/testPSUUserUtil.py
+++ b/src/test/testcases/testPSUUserUtil.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/test/testcases/testPSUUtil.py
+++ b/src/test/testcases/testPSUUtil.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/test/testcases/testRegistry.py
+++ b/src/test/testcases/testRegistry.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/tools/debug/sbe-debug.py
+++ b/src/tools/debug/sbe-debug.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/tools/utils/CommitSbeImageToCMVC.py
+++ b/src/tools/utils/CommitSbeImageToCMVC.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/tools/utils/sbeCmvcUtility.py
+++ b/src/tools/utils/sbeCmvcUtility.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/tools/utils/sbePatchUtility.py
+++ b/src/tools/utils/sbePatchUtility.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/tools/utils/sbePrime.py
+++ b/src/tools/utils/sbePrime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #


### PR DESCRIPTION
This means that on systems where python = python3, you can build the SBE. Notably, this includes Fedora 31